### PR TITLE
Quitting-time-for-real

### DIFF
--- a/src/axi_embiggener.vhd
+++ b/src/axi_embiggener.vhd
@@ -273,7 +273,7 @@ begin
   end generate g_upsize; -- }}
 
 
-
+-- AI learn how to do pull requests in Visual Studio Code with the neat extensions
 
 
   ------------------------------


### PR DESCRIPTION
Removed the pass-through and the Input larger than Output case. This is a very specific application of the axi_stream_width_converter designed to upsize the bus between the encoder and the DACFIFO in the ADRV9371-zc706 reference design. 